### PR TITLE
Remove problematic javascript/style links and s3 gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,7 +45,6 @@ gem 'jbuilder', '~> 2.0'
 gem 'sdoc', '~> 0.4.0',          group: :doc
 
 gem 'spring',        group: :development
-gem 'aws-s3', :require => 'aws/s3'
 gem 'figaro'
 gem 'nokogiri'
 gem 'sidekiq'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -40,10 +40,6 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.3.8)
     arel (5.0.1.20140414130214)
-    aws-s3 (0.6.3)
-      builder
-      mime-types
-      xml-simple
     bcrypt (3.1.10)
     bootstrap-sass (3.2.0.2)
       sass (~> 3.2)
@@ -256,7 +252,6 @@ GEM
     will_paginate (3.0.7)
     will_paginate-bootstrap (1.0.1)
       will_paginate (>= 3.0.3)
-    xml-simple (1.1.5)
     xpath (2.0.0)
       nokogiri (~> 1.3)
 
@@ -264,7 +259,6 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  aws-s3
   bootstrap-sass (~> 3.2.0.2)
   bootstrap-sass-rails (~> 2.2.2.0)
   capybara

--- a/app/views/songs/show.html.erb
+++ b/app/views/songs/show.html.erb
@@ -1,8 +1,6 @@
 <head>
   <title>Audio Player</title>
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.7.2/jquery.min.js"></script>
-  <script src="js/mediaelement-and-player.min.js"></script>
-  <link rel="stylesheet" href="style.css" media="screen">
 </head>
 <body>
   <div>

--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -6,7 +6,7 @@
   <div class="text-center">
     <div class="container-fluid">
       <h1>Psalm Hub</h1>
-      <p><%= render partial: "shared/audio_player", locals: {song: @random_song} %></p>
+      <p><%= render partial: "shared/audio_player", locals: {song: @random_song} unless @random_song.nil? %></p>
     </div>
   </div>
 </div>

--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -1,8 +1,6 @@
 <head>
   <title>Psalm Hub</title>
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.7.2/jquery.min.js"></script>
-  <script src="js/mediaelement-and-player.min.js"></script>
-  <link rel="stylesheet" href="css/style.css" media="screen">
 </head>
 <div class="jumbotron">
   <div class="text-center">

--- a/config/application.rb
+++ b/config/application.rb
@@ -16,11 +16,6 @@ Bundler.require(*Rails.groups)
 
 module PsalmHub
   class Application < Rails::Application
-    AWS::S3::Base.establish_connection!(
-      :access_key_id     => ENV["AWS_ACCESS_KEY_ID"],
-      :secret_access_key => ENV["AWS_SECRET_ACCESS_KEY"]
-    )
-
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.


### PR DESCRIPTION
A few things in this PR:
- remove problematic javascript / stylesheet links
- remove s3 that is outdated and no longer supported
- when the app is just starting, there might not be any songs to play. in this edge case, don't display player on landing page